### PR TITLE
Port & rename cluster property `zone: str` -> `zones: []`

### DIFF
--- a/gke-fleets-with-argocd/config.yaml
+++ b/gke-fleets-with-argocd/config.yaml
@@ -28,15 +28,15 @@ clustersConfig:  # a list of one or more clusters, each with their own config
 - clusterName: "mccp-central-01"
   machineType: "e2-standard-4"
   region: "us-central1" 
-  zone: "us-central1-b"  
+  zones: ["us-central1-b"]
   subnetName: "us-central1"
 - clusterName: "gke-std-east01"
   machineType: "e2-standard-4"
   region: "us-east1" 
-  zone: "us-east1-b"  
+  zones: ["us-east1-b"]
   subnetName: "us-east1"
 - clusterName: "gke-std-west01"
   machineType: "e2-standard-4"
   region: "us-west1" 
-  zone: "us-west1-b"  
+  zones: ["us-west1-b"]
   subnetName: "us-west1"

--- a/gke-fleets-with-config-sync-and-argo-rollouts/config.yaml
+++ b/gke-fleets-with-config-sync-and-argo-rollouts/config.yaml
@@ -28,15 +28,15 @@ clustersConfig:  # a list of one or more clusters, each with their own config
 - clusterName: "mccp-central-01"
   machineType: "e2-standard-4"
   region: "us-central1" 
-  zone: "us-central1-b"  
+  zones: ["us-central1-b"]
   subnetName: "us-central1"
 - clusterName: "gke-std-east01"
   machineType: "e2-standard-4"
   region: "us-east1" 
-  zone: "us-east1-b"  
+  zones: ["us-east1-b"]
   subnetName: "us-east1"
 - clusterName: "gke-std-west01"
   machineType: "e2-standard-4"
   region: "us-west1" 
-  zone: "us-west1-b"  
+  zones: ["us-west1-b"]
   subnetName: "us-west1"

--- a/multi-cluster-network-resiliency/config.yaml
+++ b/multi-cluster-network-resiliency/config.yaml
@@ -29,20 +29,20 @@ clustersConfig:  # a list of one or more clusters, each with their own config
 - clusterName: "gke-central"
   machineType: "e2-standard-4"
   region: "us-central1" 
-  zone: "us-central1-a"  
+  zones: ["us-central1-a"]
   subnetName: "us-central1"
 - clusterName: "gke-east"
   machineType: "e2-standard-4"
   region: "us-east1"
-  zone: "us-east1-b" 
+  zones: ["us-east1-b"]
   subnetName: "us-east1"
 - clusterName: "gke-west"
   machineType: "e2-standard-4"
   region: "us-west1"
-  zone: "us-west1-b" 
+  zones: ["us-west1-b"]
   subnetName: "us-west1"
 - clusterName: "gke-eu-north"
   machineType: "e2-standard-4"
   region: "europe-north1"
-  zone: "europe-north1-c" 
+  zones: ["europe-north1-c"]
   subnetName: "europe-north1"

--- a/online-boutique-single-cluster/config.yaml
+++ b/online-boutique-single-cluster/config.yaml
@@ -29,5 +29,5 @@ clustersConfig:
 - clusterName: "gke-central"
   machineType: "e2-standard-4"
   region: "us-central1"
-  zone: "us-central1-a"  
+  zones: ["us-central1-a"]
   subnetName: "us-central1"


### PR DESCRIPTION
Had issues Terraform cluster creation failing due to failure to slice `zones`: 
```
Error: Invalid function argument

  on .terraform/modules/cluster_build.gke_module.gke/modules/beta-private-cluster/main.tf line 40, in locals:
  40:   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))
```

It turned out that the config yaml produced from following steps at https://github.com/barbatron/gke-poc-toolkit-demos/blob/main/gke-fleets-with-argocd/README.md produced cluster config with singular `zone` fields. Changing these to `zones` arrays solved the problem.
